### PR TITLE
simple decoupling

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,132 +4,132 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-absl-py==0.9.0
-alembic==1.4.2
-astor==0.8.1
-astunparse==1.6.3
-azure-core==1.7.0
-azure-storage-blob==12.3.2
-backcall==0.2.0
-cachetools==4.1.1
-certifi==2020.6.20
-cffi==1.14.0
-chardet==3.0.4
-click==7.1.2
-cloudpickle==1.5.0
-cmdstanpy==0.4.0
-colour==0.1.5
-convertdate==2.2.1
-cryptography==2.9.2
-cycler==0.10.0
-Cython==0.29.21
-databricks-cli==0.11.0
-dateparser==0.7.6
-decorator==4.4.2
-docker==4.2.2
-entrypoints==0.3
-ephem==3.7.7.1
-fbprophet==0.6
-Flask==1.1.2
-gast==0.3.3
-geojson==2.5.0
-gitdb==4.0.5
-GitPython==3.1.7
-google-auth==1.19.2
-google-auth-oauthlib==0.4.1
-google-pasta==0.2.0
-gorilla==0.3.0
-grpcio==1.30.0
-gunicorn==20.0.4
-h5py==2.10.0
-holidays==0.10.2
-idna==2.10
-ipykernel==5.3.3
-ipython==7.16.1
-ipython-genutils==0.2.0
-isodate==0.6.0
-itsdangerous==1.1.0
-jedi==0.17.2
-Jinja2==2.11.2
-joblib==0.16.0
-jupyter-client==6.1.6
-jupyter-core==4.6.3
-Keras==2.4.3
-Keras-Applications==1.0.8
-Keras-Preprocessing==1.1.2
-kiwisolver==1.2.0
-korean-lunar-calendar==0.2.1
-llvmlite==0.33.0
-LunarCalendar==0.0.9
-lxml==4.5.2
-Mako==1.1.3
-Markdown==3.2.2
-MarkupSafe==1.1.1
-matplotlib==3.3.0
-mlflow==1.9.1
-mpld3==0.5.1
-msrest==0.6.17
-numba==0.50.1
-numpy==1.19.0
-oauthlib==3.1.0
-opt-einsum==3.3.0
-pandas==1.0.5
-parso==0.7.0
-pexpect==4.8.0
-pickleshare==0.7.5
-Pillow==7.2.0
-pixiedust==1.1.18
-prometheus-api-client @ https://github.com/4n4nd/prometheus-api-client-python/zipball/v0.0.2
-prometheus-client==0.8.0
-prometheus-flask-exporter==0.15.0
-prompt-toolkit==3.0.5
-protobuf==3.12.2
-ptyprocess==0.6.0
-pyasn1==0.4.8
-pyasn1-modules==0.2.8
-pycparser==2.20
-Pygments==2.6.1
-PyMeeus==0.3.7
-pyparsing==2.4.7
-pyprof2calltree==1.4.5
-pystan==2.19.1.1
-python-dateutil==2.8.1
-python-dotenv==0.14.0
-python-editor==1.0.4
-pytz==2020.1
-PyYAML==5.3.1
-pyzmq==19.0.1
-querystring-parser==1.2.4
-regex==2020.7.14
-requests==2.24.0
-requests-oauthlib==1.3.0
-retrying==1.3.3
-rsa==4.6
-schedule==0.6.0
-scikit-learn==0.23.1
-scipy==1.4.1
-setuptools-git==1.2
-six==1.15.0
-sklearn==0.0
-smmap==3.0.4
-SQLAlchemy==1.3.13
-sqlparse==0.3.1
-tabulate==0.8.7
-tensorboard==2.2.2
-tensorboard-plugin-wit==1.7.0
-tensorflow==2.2.0
-tensorflow-estimator==2.2.0
-termcolor==1.1.0
-threadpoolctl==2.1.0
-tornado==6.0.4
-traitlets==4.3.3
-tzlocal==2.1
-urllib3==1.25.9
-uuid==1.30
-wcwidth==0.2.5
-websocket-client==0.57.0
-Werkzeug==1.0.1
-wrapt==1.12.1
+absl-py = "==0.9.0"
+alembic = "==1.4.2"
+astor = "==0.8.1"
+astunparse = "==1.6.3"
+azure-core = "==1.7.0"
+azure-storage-blob = "==12.3.2"
+backcall = "==0.2.0"
+cachetools = "==4.1.1"
+certifi = "==2020.6.20"
+cffi = "==1.14.0"
+chardet = "==3.0.4"
+click = "==7.1.2"
+cloudpickle = "==1.5.0"
+cmdstanpy = "==0.4.0"
+colour = "==0.1.5"
+convertdate = "==2.2.1"
+cryptography = "==2.9.2"
+cycler = "==0.10.0"
+Cython = "==0.29.21"
+databricks-cli = "==0.11.0"
+dateparser = "==0.7.6"
+decorator = "==4.4.2"
+docker = "==4.2.2"
+entrypoints = "==0.3"
+ephem = "==3.7.7.1"
+fbprophet = "==0.6"
+Flask = "==1.1.2"
+gast = "==0.3.3"
+geojson = "==2.5.0"
+gitdb = "==4.0.5"
+GitPython = "==3.1.7"
+google-auth = "==1.19.2"
+google-auth-oauthlib = "==0.4.1"
+google-pasta = "==0.2.0"
+gorilla = "==0.3.0"
+grpcio = "==1.30.0"
+gunicorn = "==20.0.4"
+h5py = "==2.10.0"
+holidays = "==0.10.2"
+idna = "==2.10"
+ipykernel = "==5.3.3"
+ipython = "==7.16.1"
+ipython-genutils = "==0.2.0"
+isodate = "==0.6.0"
+itsdangerous = "==1.1.0"
+jedi = "==0.17.2"
+Jinja2 = "==2.11.2"
+joblib = "==0.16.0"
+jupyter-client = "==6.1.6"
+jupyter-core = "==4.6.3"
+Keras = "==2.4.3"
+Keras-Applications = "==1.0.8"
+Keras-Preprocessing = "==1.1.2"
+kiwisolver = "==1.2.0"
+korean-lunar-calendar = "==0.2.1"
+llvmlite = "==0.33.0"
+LunarCalendar = "==0.0.9"
+lxml = "==4.5.2"
+Mako = "==1.1.3"
+Markdown = "==3.2.2"
+MarkupSafe = "==1.1.1"
+matplotlib = "==3.3.0"
+mlflow = "==1.9.1"
+mpld3 = "==0.5.1"
+msrest = "==0.6.17"
+numba = "==0.50.1"
+numpy = "==1.19.0"
+oauthlib = "==3.1.0"
+opt-einsum = "==3.3.0"
+pandas = "==1.0.5"
+parso = "==0.7.0"
+pexpect = "==4.8.0"
+pickleshare = "==0.7.5"
+Pillow = "==7.2.0"
+pixiedust = "==1.1.18"
+prometheus-api-client = "*"
+prometheus-client = "==0.8.0"
+prometheus-flask-exporter = "==0.15.0"
+prompt-toolkit = "==3.0.5"
+protobuf = "==3.12.2"
+ptyprocess = "==0.6.0"
+pyasn1 = "==0.4.8"
+pyasn1-modules = "==0.2.8"
+pycparser = "==2.20"
+Pygments = "==2.6.1"
+PyMeeus = "==0.3.7"
+pyparsing = "==2.4.7"
+pyprof2calltree = "==1.4.5"
+pystan = "==2.19.1.1"
+python-dateutil = "==2.8.1"
+python-dotenv = "==0.14.0"
+python-editor = "==1.0.4"
+pytz = "==2020.1"
+PyYAML = "==5.3.1"
+pyzmq = "==19.0.1"
+querystring-parser = "==1.2.4"
+regex = "==2020.7.14"
+requests = "==2.24.0"
+requests-oauthlib = "==1.3.0"
+retrying = "==1.3.3"
+rsa = "==4.6"
+schedule = "==0.6.0"
+scikit-learn = "==0.23.1"
+scipy = "==1.4.1"
+setuptools-git = "==1.2"
+six = "==1.15.0"
+sklearn = "==0.0"
+smmap = "==3.0.4"
+SQLAlchemy = "==1.3.13"
+sqlparse = "==0.3.1"
+tabulate = "==0.8.7"
+tensorboard = "==2.2.2"
+tensorboard-plugin-wit = "==1.7.0"
+tensorflow = "==2.2.0"
+tensorflow-estimator = "==2.2.0"
+termcolor = "==1.1.0"
+threadpoolctl = "==2.1.0"
+tornado = "==6.0.4"
+traitlets = "==4.3.3"
+tzlocal = "==2.1"
+urllib3 = "==1.25.9"
+uuid = "==1.30"
+wcwidth = "==0.2.5"
+websocket-client = "==0.57.0"
+Werkzeug = "==1.0.1"
+wrapt = "==1.12.1"
 
 [requires]
 python_version = "3.8"

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from configuration import Configuration
 import schedule
 import sys
 import pickle
+from model_marshal import dump_model_list, load_model_list
 
 # Set up logging
 _LOGGER = logging.getLogger(__name__)
@@ -218,11 +219,8 @@ def train_model(initial_run=False):
 
         predictor_model.predicted_df["size"] = predictor_model_size
 
-    try:
-        with open( "predictor_model_list.p", "wb" ) as f:
-            pickle.dump(PREDICTOR_MODEL_LIST, f)
-    except pickle.PickleError as e:
-        raise e
+    
+    dump_model_list(PREDICTOR_MODEL_LIST)
 
 
 def build_predictions(data_queue=None):
@@ -236,9 +234,7 @@ def load_models(data_queue=None):
         
     _PREDICTOR_MODEL_LIST = None
     try:
-        with open( "predictor_model_list.p", "rb" ) as f:
-            _PREDICTOR_MODEL_LIST = pickle.load( f )
-        PREDICTOR_MODEL_LIST = _PREDICTOR_MODEL_LIST
+        PREDICTOR_MODEL_LIST = load_model_list()
         build_predictions(data_queue)
     except pickle.UnpicklingError as e:
         raise e

--- a/model_marshal.py
+++ b/model_marshal.py
@@ -17,14 +17,14 @@ import sys
 import pickle
 import uuid
 import itertools
-import model as model_fourier
+import model as model_prophet
 import json
 import hashlib
 
 
 def dumps_model(model):    
-    if isinstance(model, model_fourier.MetricPredictor):
-        logger.debug("Marshal model_fourier.MetricPredictor object {0}".format(model.id))
+    if isinstance(model, model_prophet.MetricPredictor):
+        logger.debug("Marshal {0} object {1}".format(model_prophet.MetricPredictor.__name__, model.id))
         try:
             return pickle.dumps(model)
         except Exceptions as e:
@@ -34,10 +34,10 @@ def dumps_model(model):
 
 
 def loads_model(cls, data):
-    if issubclass(cls, model_fourier.MetricPredictor):
+    if issubclass(cls, model_prophet.MetricPredictor):
         try:
             model = pickle.loads(data)
-            logger.debug("Unmarshal model_fourier.MetricPredictor object {0}".format(model.id))
+            logger.debug("Unmarshal as {0} object {1}".format(model_prophet.MetricPredictor.__name__, model.id))
             return model
         except Exceptions as e:
             raise e
@@ -53,7 +53,7 @@ def dump_model_list(l):
     for (key, value) in x.items():
         obj = value
         cls_name = None
-        if isinstance(obj, model_fourier.MetricPredictor):
+        if isinstance(obj, model_prophet.MetricPredictor):
             cls_name = "fourier"
         else:
             raise NotImplementedError("Unknown model type cannot be identified")
@@ -112,7 +112,7 @@ def load_model_list():
             raise Exception("checksum does not match")
 
         if cls_name == "fourier":
-            cls = model_fourier.MetricPredictor
+            cls = model_prophet.MetricPredictor
         else:
             raise NotImplementedError("Model class cannot be mapped to serializer")
 

--- a/model_marshal.py
+++ b/model_marshal.py
@@ -54,7 +54,7 @@ def dump_model_list(l):
         obj = value
         cls_name = None
         if isinstance(obj, model_prophet.MetricPredictor):
-            cls_name = "fourier"
+            cls_name = "prophet"
         else:
             raise NotImplementedError("Unknown model type cannot be identified")
 
@@ -111,7 +111,7 @@ def load_model_list():
         if hashlib.md5(data).hexdigest() != md5:
             raise Exception("checksum does not match")
 
-        if cls_name == "fourier":
+        if cls_name == "prophet":
             cls = model_prophet.MetricPredictor
         else:
             raise NotImplementedError("Model class cannot be mapped to serializer")

--- a/model_marshal.py
+++ b/model_marshal.py
@@ -1,0 +1,125 @@
+"""Global marshal/unmarshal methods
+Temporary replacement for type-polymorphic dump method.
+so that model classes are not changed."""
+import time
+import os
+import logging
+from datetime import datetime, timedelta
+from multiprocessing import Process, Queue
+from queue import Empty as EmptyQueueException
+import tornado.ioloop
+import tornado.web
+from prometheus_client import Gauge, generate_latest, REGISTRY
+from prometheus_api_client import PrometheusConnect, Metric
+from configuration import Configuration
+import schedule
+import sys
+import pickle
+import uuid
+import itertools
+import model as model_fourier
+import json
+import hashlib
+
+
+def dumps_model(model):    
+    if isinstance(model, model_fourier.MetricPredictor):
+        logger.debug("Marshal model_fourier.MetricPredictor object {0}".format(model.id))
+        try:
+            return pickle.dumps(model)
+        except Exceptions as e:
+            raise e
+    else:
+        raise NotImplementedError("Unknown model type cannot be marshalled")
+
+
+def loads_model(cls, data):
+    if issubclass(cls, model_fourier.MetricPredictor):
+        try:
+            model = pickle.loads(data)
+            logger.debug("Unmarshal model_fourier.MetricPredictor object {0}".format(model.id))
+            return model
+        except Exceptions as e:
+            raise e
+    else:
+        raise NotImplementedError("Unknown model type cannot be unmarshalled")
+
+
+def dump_model_list(l):
+    logger.info("Marshalling model list")
+    x = dict(zip(itertools.starmap(uuid.uuid4, itertools.repeat([])), l))
+    x_txt = dict()
+
+    for (key, value) in x.items():
+        obj = value
+        cls_name = None
+        if isinstance(obj, model_fourier.MetricPredictor):
+            cls_name = "fourier"
+        else:
+            raise NotImplementedError("Unknown model type cannot be identified")
+
+        data = dumps_model(obj)
+        x_txt[str(key)] = {
+            "name": "{0}.p".format(key.hex),
+            "class": cls_name,
+            "size": len(data),
+            "md5": hashlib.md5(data).hexdigest()
+        }
+        # saving marshaled data instead of the object
+        x[key] = data
+    
+    try:
+        with open("predictor_model_list.json", "w") as f:
+            data = json.dumps(list(x_txt.values()))
+            f.write(data)
+    except Exception as e:
+        raise e
+
+    for (key, value) in x.items():
+        fname = x_txt[str(key)]["name"]
+        data = value
+        try:
+            with open(fname, "wb") as f:
+                f.write(data)
+        except Exception as e:
+            raise e
+
+def load_model_list():
+    x = list()
+    x_list = list()
+    try:
+        with open("predictor_model_list.json", "r") as f:
+            data = f.read()
+            x_list = json.loads(data)
+            # x_txt = dict(zip(itertools.starmap(uuid.uuid4, itertools.repeat([])), x_list))
+    except Exception as e:
+        raise e
+    
+    for value in x_list:
+        fname = value["name"]
+        fsize = value["size"]
+        cls_name = value["class"]
+        md5 = value["md5"]
+        cls = None
+
+        try:
+            with open(fname, "rb") as f:
+                data = f.read(fsize)
+        except Exception as e:
+            raise e
+
+        if hashlib.md5(data).hexdigest() != md5:
+            raise Exception("checksum does not match")
+
+        if cls_name == "fourier":
+            cls = model_fourier.MetricPredictor
+        else:
+            raise NotImplementedError("Model class cannot be mapped to serializer")
+
+        model = loads_model(cls, data)
+        if model is None:
+            raise Exception
+        x.append(model)
+
+    logger.info("successfully unmarshalled model list")
+    return x

--- a/model_marshal.py
+++ b/model_marshal.py
@@ -22,9 +22,11 @@ import json
 import hashlib
 
 
+logger = logging.getLogger(__name__)
+
 def dumps_model(model):    
     if isinstance(model, model_prophet.MetricPredictor):
-        logger.debug("Marshal {0} object {1}".format(model_prophet.MetricPredictor.__name__, model.id))
+        logger.debug("Marshal {module}.{cls} object {oiu}".format(module=model_prophet.__name__, cls=model_prophet.MetricPredictor.__name__, oiu=id(model)))
         try:
             return pickle.dumps(model)
         except Exceptions as e:
@@ -37,7 +39,7 @@ def loads_model(cls, data):
     if issubclass(cls, model_prophet.MetricPredictor):
         try:
             model = pickle.loads(data)
-            logger.debug("Unmarshal as {0} object {1}".format(model_prophet.MetricPredictor.__name__, model.id))
+            logger.debug("Unmarshal as {module}.{cls} object {oiu}".format(module=model_prophet.__name__, cls=model_prophet.MetricPredictor.__name__, oiu=id(model)))
             return model
         except Exceptions as e:
             raise e
@@ -91,7 +93,6 @@ def load_model_list():
         with open("predictor_model_list.json", "r") as f:
             data = f.read()
             x_list = json.loads(data)
-            # x_txt = dict(zip(itertools.starmap(uuid.uuid4, itertools.repeat([])), x_list))
     except Exception as e:
         raise e
     


### PR DESCRIPTION
* Marshal/unmarshal the whole dict with models. I know it is an overkill but it should work for now.
* Removed retraining of the model at the end of each window by schedule.every (this needs to be tested if prediction_df is still generated). 
* instead of re-training new models are loaded. If model needs to be _actually_ retrained (lets say every FLT_RETRAINING_INTERVAL_MINUTES) the pickle file needs to be updated (call train_model for this somewhere else).